### PR TITLE
Remove port 5173

### DIFF
--- a/.cloud/docker/docker-compose.yaml
+++ b/.cloud/docker/docker-compose.yaml
@@ -7,8 +7,6 @@ services:
     restart: always
     volumes:
       - ../../frontend:/app:rw
-    ports:
-      - 5173:5173
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Port 5173 is used by the command "yarn dev".
The frontend is exposed by caddy's reverse proxy anyway.