### PR TITLE
Hide column selection

### DIFF
--- a/src/views/samples/select/table/DataTable.vue
+++ b/src/views/samples/select/table/DataTable.vue
@@ -108,7 +108,7 @@ const isFiltered = computed(() => table.getState().columnFilters.length > 0);
                 Reset
                 <Icon icon="ic:baseline-close"></Icon>
             </Button>
-            <DropdownMenu>
+            <!-- <DropdownMenu>
                 <DropdownMenuTrigger as-child>
                     <Button variant="outline" class="ml-auto">
                         Columns
@@ -132,7 +132,7 @@ const isFiltered = computed(() => table.getState().columnFilters.length > 0);
                         {{ column.id }}
                     </DropdownMenuCheckboxItem>
                 </DropdownMenuContent>
-            </DropdownMenu>
+            </DropdownMenu> -->
         </div>
         <div class="border rounded-md">
             <Table>


### PR DESCRIPTION
It's not possible to rename the items in the column selection dropdown for now.

As it is currently not used, we remove it.